### PR TITLE
fix: verify certificate chain

### DIFF
--- a/controllers/extparticipant/utils.js
+++ b/controllers/extparticipant/utils.js
@@ -1,6 +1,7 @@
 /* eslint-disable snakecase/snakecase */
 const config_service = require('../../lib/configService.js');
 const debug = require('debug')('idm:extparticipant_utils');
+const crypto = require('crypto');
 const fetch = require('node-fetch');
 const forge = require('node-forge');
 const jose = require('node-jose');
@@ -12,7 +13,6 @@ const config = config_service.get_config();
 
 const crt_regex = /^-----BEGIN CERTIFICATE-----\n([\s\S]+?)\n-----END CERTIFICATE-----$/gm;
 exports.verifier = jose.JWS.createVerify();
-const root_ca_store = forge.pki.createCaStore();
 
 const ensure_client_key_is_ready = async function ensure_client_key_is_ready() {
   if (typeof config.pr.client_key === 'string') {
@@ -47,11 +47,29 @@ const serialize_attributes = function serialize_attributes(a) {
   return `${oid}=${value}`;
 };
 
-exports.verify_certificate_chain = function verify_certificate_chain(chain) {
-  return forge.pki.verifyCertificateChain(root_ca_store, chain);
+const cert_is_trusted = function cert_is_trusted(cert) {
+  const trusted_list = get_trusted_list();
+  const fingerprint = new crypto.X509Certificate(forge.pki.certificateToPem(cert)).fingerprint256.replaceAll(':', '');
+  return trusted_list.includes(fingerprint);
 };
 
-exports.validate_client_certificate = function validate_client_certificate(chain) {
+exports.verify_certificate_chain = async function verify_certificate_chain(chain) {
+  // Verify the certificate chain one by one
+  let result = true;
+  for (let i = 0; i < chain.length - 2 && result; i++) {
+    const subject = chain[i];
+    if (cert_is_trusted(subject)) {
+      debug(`Certificate ${i} is trusted`);
+      return result;
+    }
+    const issuer = chain[i + 1];
+    result = result && issuer.verify(subject);
+  }
+  result = result && (await cert_is_trusted(chain[chain.length - 1]));
+  return result;
+};
+
+exports.validate_client_certificate = async function validate_client_certificate(chain) {
   const errors = [];
   const cert = chain[0];
 
@@ -61,7 +79,9 @@ exports.validate_client_certificate = function validate_client_certificate(chain
   // if (period_start != null) {
   //   check(errors, cert.validity.notBefore <= period_start && period_end <= cert.validity.notAfter, "Certificate dates invalid.");
   // }
-  //check(errors, exports.verify_certificate_chain(chain), "Certificate is not part of the chain");
+
+  const chain_is_verified = await exports.verify_certificate_chain(chain);
+  check(errors, chain_is_verified, 'Certificate chain cannot be verified.');
   check(errors, cert.signatureOid === forge.pki.oids.sha256WithRSAEncryption, 'Certificate signature invalid');
   check(errors, cert.publicKey.n.bitLength() >= 2048, 'Certificate public key size is smaller than 2048');
   check(errors, cert.serialNumber != null && cert.serialNumber.trim() !== '', 'Certificate has no serial number');
@@ -153,33 +173,7 @@ exports.validate_participant_from_jwt = async function validate_participant_from
   client_payload,
   client_certificate
 ) {
-  /*******/
-  debug('Generating a JWT token for accessing the participant registry');
-  /*******/
-  const token = await retrieve_participant_registry_token();
-
-  /*******/
-  debug('Requesting an access token to the participant registry');
-  /*******/
-
-  const params = new URLSearchParams();
-  params.append('grant_type', 'client_credentials');
-  params.append('scope', 'iSHARE');
-  params.append('client_id', config.pr.client_id);
-  params.append('client_assertion_type', 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer');
-  params.append('client_assertion', token);
-
-  debug('url: ' + config.pr.token_endpoint);
-  debug('body: ' + params);
-  const token_response = await fetch(config.pr.token_endpoint, {
-    method: 'post',
-    body: params
-  });
-  if (token_response.status !== 200) {
-    throw new oauth2_server.ServerError('internal error: unable to validate client as participant');
-  }
-
-  const access_token = (await token_response.json()).access_token;
+  const access_token = await get_access_token();
 
   /*******/
   debug('Querying participant registry if the client is a valid participant');
@@ -232,3 +226,108 @@ exports.create_jwt = async function create_jwt(payload) {
     .final();
 };
 /* eslint-enable snakecase/snakecase */
+
+const get_access_token = (function () {
+  // Cache for the access token
+  let pending = false;
+  let access_token = null;
+  let expires_at = null;
+
+  // Fetch a new access token
+  async function fetch_access_token() {
+    pending = true;
+    debug('Generating a JWT token for accessing the participant registry');
+    const token = await retrieve_participant_registry_token();
+
+    debug('Requesting an access token to the participant registry');
+    const params = new URLSearchParams();
+    params.append('grant_type', 'client_credentials');
+    params.append('scope', 'iSHARE');
+    params.append('client_id', config.pr.client_id);
+    params.append('client_assertion_type', 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer');
+    params.append('client_assertion', token);
+
+    debug('url: ' + config.pr.token_endpoint);
+    debug('token: ' + token);
+    const token_response = await fetch(config.pr.token_endpoint, {
+      method: 'post',
+      body: params
+    });
+
+    debug('response status: ' + token_response.status);
+    if (token_response.status !== 200) {
+      throw new oauth2_server.ServerError('internal error: unable to validate client as participant');
+    }
+
+    const response = await token_response.json();
+    expires_at = moment().add(response.expires_in - 1, 'seconds');
+    pending = false;
+    return response.access_token;
+  }
+
+  // Return a promise that resolves to the access token.
+  return async function inner_get_access_token() {
+    if (pending) {
+      debug('Access token is pending.');
+      return await access_token;
+    } else if (access_token != null && expires_at > moment()) {
+      debug('Using cached access token.');
+      return access_token;
+    } else {
+      access_token = fetch_access_token();
+      return await access_token;
+    }
+  };
+})();
+
+const get_trusted_list = (function () {
+  let old_trusted_list = null;
+  let trusted_list = null;
+  let pending = true;
+
+  // Fetch a new trusted list
+  async function fetch_trusted_list() {
+    const access_token = await get_access_token();
+    const trusted_list_response = await fetch(config.pr.url + '/trusted_list', {
+      headers: {
+        Authorization: 'Bearer ' + access_token
+      }
+    });
+    const trusted_jwt_cert_list = await exports.verifier.verify(
+      (
+        await trusted_list_response.json()
+      ).trusted_list_token,
+      // eslint-disable-next-line snakecase/snakecase
+      { allowEmbeddedKey: true }
+    );
+
+    const trusted_list_json = JSON.parse(trusted_jwt_cert_list.payload.toString()).trusted_list;
+
+    const trusted_list_fingerprints = trusted_list_json.map((cert) => {
+      return cert.certificate_fingerprint;
+    });
+    trusted_list = await trusted_list_fingerprints;
+  }
+
+  function refresh_trusted_list() {
+    pending = true;
+    old_trusted_list = trusted_list;
+    fetch_trusted_list().then(() => {
+      pending = false;
+    });
+  }
+
+  refresh_trusted_list();
+  // eslint-disable-next-line snakecase/snakecase
+  setInterval(refresh_trusted_list, config.pr.trusted_list_fetch_interval * 1000);
+
+  // Get the trusted list (fetching it if necessary).
+  return function inner_get_trusted_list() {
+    if (pending) {
+      debug('Trusted list is pending.');
+      return old_trusted_list;
+    } else {
+      return trusted_list;
+    }
+  };
+})();


### PR DESCRIPTION
## Proposed changes

When asserting client using JWT, added verification of the certificate chain when validating the client certificate including checking that a certificate in the chain matches one in the trusted list.


